### PR TITLE
イベント登録機能

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,8 +14,12 @@ before_action :move_to_index, except: [:index, :show]
 
   def create
     @event = Event.new(event_params)
-    @event.save
-    redirect_to root_path
+    if @event.valid?
+      @event.save
+      redirect_to root_path
+    else
+      render :new
+    end
   end
 
   def show
@@ -25,7 +29,7 @@ before_action :move_to_index, except: [:index, :show]
   private
 
   def event_params
-    params.require(:event).permit(:title, :detail, :event_date, :event_time, :category_id)
+    params.require(:event).permit(:title, :detail, :event_date, :event_time, :category_id).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,7 +1,9 @@
 <h1>入力フォーム</h1>
 
+
 <div class="Form">
   <%= form_with model: @event, local: true do |f| %>
+  <%= render "shared/error_messages", model: f.object %>
   <div class="Form-Item">
       <span class="Form-Item-Label-Required">必須</span>
       イベント名


### PR DESCRIPTION
#What
イベント（予定やTodo）を登録する機能の実装

#Why
イベントを登録し、表示させることで、ユーザーが予定を把握することができるため。